### PR TITLE
Do not set an initial value for directory_start

### DIFF
--- a/browsepy/__init__.py
+++ b/browsepy/__init__.py
@@ -36,7 +36,7 @@ app = Flask(
     )
 app.config.update(
     directory_base=compat.getcwd(),
-    directory_start=compat.getcwd(),
+    directory_start=None,
     directory_remove=None,
     directory_upload=None,
     directory_tar_buffsize=262144,


### PR DESCRIPTION
Otherwise if browsepy is started with a config where directory_base is not a parent of directory_start we get a 404.