### PR TITLE
Ignoring unsupported pathconf keys

### DIFF
--- a/browsepy/compat.py
+++ b/browsepy/compat.py
@@ -11,6 +11,7 @@ import functools
 
 import posixpath
 import ntpath
+import errno
 
 FS_ENCODING = sys.getfilesystemencoding()
 PY_LEGACY = sys.version_info < (3, )
@@ -252,8 +253,11 @@ def pathconf(path,
         for key in pathconf_names:
             try:
                 pathconf_output[key] = pathconf_fnc(path, key)
-            except OSError:
-                pass
+            except OSError as exc:
+                if exc.errno == errno.EINVAL:
+                    pass  # Ignoring unsupported pathconf key
+                else:
+                    raise exc from None
         return pathconf_output
     if os_name == 'nt':
         maxpath = 246 if isdir_fnc(path) else 259  # 260 minus <END>

--- a/browsepy/compat.py
+++ b/browsepy/compat.py
@@ -248,7 +248,14 @@ def pathconf(path,
     '''
 
     if pathconf_fnc and pathconf_names:
-        return {key: pathconf_fnc(path, key) for key in pathconf_names}
+        pathconf_output = {}
+        for key in pathconf_names:
+            try:
+                pathconf_output[key] = pathconf_fnc(path, key)
+            except OSError:
+                print(f"pathconf key {key} unsupported for this platform")
+                pass
+        return pathconf_output
     if os_name == 'nt':
         maxpath = 246 if isdir_fnc(path) else 259  # 260 minus <END>
     else:

--- a/browsepy/compat.py
+++ b/browsepy/compat.py
@@ -253,7 +253,6 @@ def pathconf(path,
             try:
                 pathconf_output[key] = pathconf_fnc(path, key)
             except OSError:
-                print(f"pathconf key {key} unsupported for this platform")
                 pass
         return pathconf_output
     if os_name == 'nt':

--- a/browsepy/compat.py
+++ b/browsepy/compat.py
@@ -254,10 +254,8 @@ def pathconf(path,
             try:
                 pathconf_output[key] = pathconf_fnc(path, key)
             except OSError as exc:
-                if exc.errno == errno.EINVAL:
-                    pass  # Ignoring unsupported pathconf key
-                else:
-                    raise exc from None
+                if exc.errno != errno.EINVAL:
+                    raise
         return pathconf_output
     if os_name == 'nt':
         maxpath = 246 if isdir_fnc(path) else 259  # 260 minus <END>


### PR DESCRIPTION
Running on macOS Catalina 10.15.7, python 3.7, I get the following exception traceback when trying to upload a file:

```
[2021-08-04 14:34:07,077] ERROR in app: Exception on /upload [POST]
Traceback (most recent call last):
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 2070, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1515, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1513, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1499, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users//PycharmProjects/browsepy/browsepy/__init__.py", line 275, in upload
    filename = directory.choose_filename(filename)
  File "/Users//PycharmProjects/browsepy/browsepy/file.py", line 668, in choose_filename
    limit = self.pathconf.get('PC_NAME_MAX', 0)
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/werkzeug/utils.py", line 97, in __get__
    value = self.fget(obj)  # type: ignore
  File "/Users//PycharmProjects/browsepy/browsepy/file.py", line 155, in pathconf
    return compat.pathconf(self.path)
  File "/Users//PycharmProjects/browsepy/browsepy/compat.py", line 252, in pathconf
    return {key: pathconf_fnc(path, key) for key in pathconf_names}
  File "/Users//PycharmProjects/browsepy/browsepy/compat.py", line 252, in <dictcomp>
    return {key: pathconf_fnc(path, key) for key in pathconf_names}
OSError: [Errno 22] Invalid argument
[2021-08-04 14:34:07,079] ERROR in __init__: 500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.
Traceback (most recent call last):
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 2070, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1515, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1513, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/flask/app.py", line 1499, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
  File "/Users//PycharmProjects/browsepy/browsepy/__init__.py", line 275, in upload
    filename = directory.choose_filename(filename)
  File "/Users//PycharmProjects/browsepy/browsepy/file.py", line 668, in choose_filename
    limit = self.pathconf.get('PC_NAME_MAX', 0)
  File "/Users//PycharmProjects/browsepy/venv/lib/python3.7/site-packages/werkzeug/utils.py", line 97, in __get__
    value = self.fget(obj)  # type: ignore
  File "/Users//PycharmProjects/browsepy/browsepy/file.py", line 155, in pathconf
    return compat.pathconf(self.path)
  File "/Users//PycharmProjects/browsepy/browsepy/compat.py", line 252, in pathconf
    return {key: pathconf_fnc(path, key) for key in pathconf_names}
  File "/Users//PycharmProjects/browsepy/browsepy/compat.py", line 252, in <dictcomp>
    return {key: pathconf_fnc(path, key) for key in pathconf_names}
OSError: [Errno 22] Invalid argument

```

Debugging a little bit the `pathconf_fnc` method, I see it fails for the following keys:

```
pathconf OSError for key PC_MAX_CANON
pathconf OSError for key PC_MAX_INPUT
pathconf OSError for key PC_VDISABLE
```

According to python's documentation for `pathconf` (https://docs.python.org/3/library/os.html#os.pathconf):

> If a specific value for name is not supported by the host system, even if it is included in pathconf_names, an OSError is raised with errno.EINVAL for the error number.

So in this PR I try to simply ignore the invalid `pathconf_names` keys. It does make the upload feature work again, but not sure about other side-effects.
