### PR TITLE
Update Manager.py function defaultsnamedtuple()

### DIFF
--- a/browsepy/manager.py
+++ b/browsepy/manager.py
@@ -6,6 +6,7 @@ import sys
 import argparse
 import warnings
 import collections
+import _collections_abc
 
 from flask import current_app
 from werkzeug.utils import cached_property
@@ -27,7 +28,7 @@ def defaultsnamedtuple(name, fields, defaults=None):
     '''
     nt = collections.namedtuple(name, fields)
     nt.__new__.__defaults__ = (None,) * len(nt._fields)
-    if isinstance(defaults, collections.Mapping):
+    if isinstance(defaults, _collections_abc.MutableMapping):
         nt.__new__.__defaults__ = tuple(nt(**defaults))
     elif defaults:
         nt.__new__.__defaults__ = tuple(nt(*defaults))


### PR DESCRIPTION
Python version 3.10.4 onwards
Getting below error as collections.Mapping is no longer present under collections module

C:\apps\Python>browsepy
Traceback (most recent call last):
  File "C:\apps\Python\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\apps\Python\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\apps\Python\Scripts\browsepy.exe\__main__.py", line 4, in <module>
  File "C:\apps\Python\lib\site-packages\browsepy\__init__.py", line 16, in <module>
    from .manager import PluginManager
  File "C:\apps\Python\lib\site-packages\browsepy\manager.py", line 188, in <module>
    class WidgetPluginManager(RegistrablePluginManager):
  File "C:\apps\Python\lib\site-packages\browsepy\manager.py", line 199, in WidgetPluginManager
    'base': defaultsnamedtuple(
  File "C:\apps\Python\lib\site-packages\browsepy\manager.py", line 30, in defaultsnamedtuple
    if isinstance(defaults, collections.MutableMapping):
AttributeError: module 'collections' has no attribute 'Mapping'


Proposed change:
import _collections_abc

Made changes in function defaultsnamedtuple, replaced     
"if isinstance(defaults, collections.Mapping):"  with "if isinstance(defaults, _collections_abc.MutableMapping):"


PS : Solution tested for python 3.10.4 only.